### PR TITLE
Add Laravel 5.8 support

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,5 +10,5 @@ checks:
 
 tools:
   external_code_coverage:
-    runs: 10
-    timeout: 1200
+    runs: 12
+    timeout: 900

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -14,13 +13,9 @@ env:
   - ILLUMINATE_VERSION=5.5.* TESTBENCH_VERSION=3.5.* PHPUNIT_VERSION=^6.0
   - ILLUMINATE_VERSION=5.6.* TESTBENCH_VERSION=3.6.* PHPUNIT_VERSION=^7.0
   - ILLUMINATE_VERSION=5.7.* TESTBENCH_VERSION=3.7.* PHPUNIT_VERSION=^7.0
+  - ILLUMINATE_VERSION=5.8.* TESTBENCH_VERSION=3.8.* PHPUNIT_VERSION=^7.0 || ^8.0
 
-matrix:    # Laravel 5.6 & 5.7 do not support PHP7.0
-  exclude:
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.6.* TESTBENCH_VERSION=3.6.* PHPUNIT_VERSION=^7.0
-    - php: 7.0
-      env: ILLUMINATE_VERSION=5.7.* TESTBENCH_VERSION=3.7.* PHPUNIT_VERSION=^7.0
+sudo: false
 
 before_install:
   - composer require laravel/framework:${ILLUMINATE_VERSION} --no-update

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Requirements
 - Laravel 5.5 or higher
-- PHP 7.0 or higher
+- PHP 7.1 or higher
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         }
     ],
     "require": {
-        "php": "^7.0",
-        "laravel/framework": "^5.5",
+        "php": "^7.1",
+        "laravel/framework": "^5.5,<5.9",
         "stevebauman/location": "^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
         "orchestra/testbench": "^3.5",
-        "phpunit/phpunit": "^6.0 || ^7.0"
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Unit/GeoMiddlewareTest.php
+++ b/tests/Unit/GeoMiddlewareTest.php
@@ -18,7 +18,7 @@ class GeoMiddlewareTest extends TestCase
     /** @var \Illuminate\Http\Request */
     protected $request;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -32,7 +32,7 @@ class GeoMiddlewareTest extends TestCase
         $this->request = $this->app->make(Request::class);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Unit/GeoRouteTest.php
+++ b/tests/Unit/GeoRouteTest.php
@@ -20,7 +20,7 @@ class GeoRouteTest extends TestCase
     /** @var \Illuminate\Routing\Router */
     protected $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -29,7 +29,7 @@ class GeoRouteTest extends TestCase
         $this->route = $this->router->get('/foo', ['uses' => '\LaraCrafts\GeoRoutes\Tests\Mocks\MockController@index', 'as' => 'qux']);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Unit/GeoRoutesMiddlewareTest.php
+++ b/tests/Unit/GeoRoutesMiddlewareTest.php
@@ -24,7 +24,7 @@ class GeoRoutesMiddlewareTest extends TestCase
     /** @var \Mockery\MockInterface */
     protected $location;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -36,7 +36,7 @@ class GeoRoutesMiddlewareTest extends TestCase
         $this->location = Mockery::mock('overload:Location');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/Unit/PackageTest.php
+++ b/tests/Unit/PackageTest.php
@@ -10,7 +10,7 @@ class PackageTest extends TestCase
     /** @var \Illuminate\Routing\Router */
     protected $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->router = $this->app->make('router');


### PR DESCRIPTION
This PR adds support for Laravel 5.8, since PHPUnit 8 and PHP 7.0 are not compatible we have to drop PHP 7.0 support. This shouldn't be a problem as PHP 7.0 is no longer supported by PHP itself.