### PR TITLE
Add the `geo` attribute.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ composer.lock
 phpunit.xml
 .php_cs
 .php_cs.cache
+.phpunit.result.cache
+.vscode/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ Route::get('/home', 'FooController@bar')->from('ca', 'de', 'fr')->deny();
 
 > ***Note:*** This package uses [*stevebauman*][4]'s [location package][5], please refer to it's [official documentation][6] for a detailed guide on how to configure it correctly.
 
+#### Manual configuration
+
+Under the hood, the `allowFrom` and the `denyFrom` methods set the `geo` attribute on the route which is an array containing the following parameters:
+- [array] **`countries`**: The list of countries covered by the *geo-constraint*.
+- [string] **`strategy`**: Determines whether to allow or deny access, the value can only be **allow** or **deny**.
+- [array] **`callback`** (optional): The callback that will be invoked once the access is denied and its arguments.
+
+Therefore, if you are more into verbosity, you can define your `GeoRoutes` in the following way:
+
+```php
+Route::get([ 'geo' => ['countries' => ['us', 'ca'], 'strategy' => 'allow', 'callback' => [$myCallback, $myArgs]] ], function() {
+    //
+});
+```
+
 ## Callbacks
 
 As mentioned earlier, the default behavior for unauthorized users is an `HTTP 401 Unauthorized Error` response, but you are still able to change this behavior by using ***callbacks***.

--- a/src/DeterminesGeoAccess.php
+++ b/src/DeterminesGeoAccess.php
@@ -21,7 +21,7 @@ trait DeterminesGeoAccess
             return $strategy !== 'allow';
         }
 
-        $requestCountry = Location::get($request->ip())->countryCode;
+        $requestCountry = Location::get()->countryCode;
 
         if ($strategy === 'allow') {
             return in_array($requestCountry, $countries);

--- a/src/DeterminesGeoAccess.php
+++ b/src/DeterminesGeoAccess.php
@@ -2,7 +2,6 @@
 
 namespace LaraCrafts\GeoRoutes;
 
-use Illuminate\Http\Request;
 use Stevebauman\Location\Facades\Location;
 
 trait DeterminesGeoAccess

--- a/src/GeoRoute.php
+++ b/src/GeoRoute.php
@@ -98,18 +98,7 @@ class GeoRoute
      */
     public function __destruct()
     {
-        $this->applyMiddleware();
-    }
-
-    /**
-     * Generate a middleware string.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return 'geo:' . $this->strategy . ',' . implode('&', $this->countries) .
-            ($this->callback ? ',' . serialize($this->callback) : '');
+        $this->applyConstraint();
     }
 
     /**
@@ -125,19 +114,25 @@ class GeoRoute
     }
 
     /**
-     * Apply the middleware to the route.
+     * Apply the geo-constraint to the route.
      */
-    protected function applyMiddleware()
+    protected function applyConstraint()
     {
         if ($this->applied || !$this->countries) {
             return;
         }
 
         $action = $this->route->getAction();
-        $action['middleware'][] = (string)$this;
+        $action['middleware'][] = 'geo';
+        $action['geo'] = [
+            'strategy' => $this->strategy,
+            'countries' => (array)$this->countries,
+            'callback' => $this->callback
+        ];
+
+        $this->route->setAction($action);
 
         $this->applied = true;
-        $this->route->setAction($action);
     }
 
     /**

--- a/src/GeoRoute.php
+++ b/src/GeoRoute.php
@@ -127,7 +127,7 @@ class GeoRoute
         $action['geo'] = [
             'strategy' => $this->strategy,
             'countries' => (array)$this->countries,
-            'callback' => $this->callback
+            'callback' => $this->callback,
         ];
 
         $this->route->setAction($action);

--- a/tests/Unit/GeoRouteTest.php
+++ b/tests/Unit/GeoRouteTest.php
@@ -43,11 +43,7 @@ class GeoRouteTest extends TestCase
         $this->assertEquals('geo', last($this->route->middleware()));
     }
 
-    /**
-     * @group def
-     *
-     * @return void
-     */
+
     public function testDefaultCallback()
     {
         (new GeoRoute($this->route, ['kr'], 'allow'));

--- a/tests/Unit/GeoRouteTest.php
+++ b/tests/Unit/GeoRouteTest.php
@@ -37,21 +37,17 @@ class GeoRouteTest extends TestCase
     public function testIfMiddlewareIsApplied()
     {
         (new GeoRoute($this->route, ['nl'], 'allow'));
-        $this->assertEquals('geo:allow,NL', last($this->route->middleware()));
+        $this->assertEquals('geo', last($this->route->middleware()));
 
-        (new GeoRoute($this->route, ['tn'], 'allow'))->allow();
-        $this->assertEquals('geo:allow,TN', last($this->route->middleware()));
-
-        (new GeoRoute($this->route, ['be'], 'deny'))->allow();
-        $this->assertEquals('geo:allow,BE', last($this->route->middleware()));
-
-        (new GeoRoute($this->route, ['jp'], 'allow'))->deny();
-        $this->assertEquals('geo:deny,JP', last($this->route->middleware()));
-
-        (new GeoRoute($this->route, ['us'], 'deny'))->deny();
-        $this->assertEquals('geo:deny,US', last($this->route->middleware()));
+        (new GeoRoute($this->route, ['tn'], 'deny'));
+        $this->assertEquals('geo', last($this->route->middleware()));
     }
 
+    /**
+     * @group def
+     *
+     * @return void
+     */
     public function testDefaultCallback()
     {
         (new GeoRoute($this->route, ['kr'], 'allow'));

--- a/tests/Unit/GeoRoutesMiddlewareTest.php
+++ b/tests/Unit/GeoRoutesMiddlewareTest.php
@@ -7,6 +7,8 @@ use LaraCrafts\GeoRoutes\Http\Middleware\GeoRoutesMiddleware;
 use LaraCrafts\GeoRoutes\Tests\TestCase;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Illuminate\Routing\Route;
+use Stevebauman\Location\Facades\Location;
 
 class GeoRoutesMiddlewareTest extends TestCase
 {
@@ -18,11 +20,14 @@ class GeoRoutesMiddlewareTest extends TestCase
     /** @var \Closure */
     protected $next;
 
-    /** @var \Illuminate\Http\Request */
+    /** @var \Mockery\MockInterface */
     protected $request;
 
     /** @var \Mockery\MockInterface */
     protected $location;
+
+    /** @var \Mockery\MockInterface */
+    protected $route;
 
     public function setUp(): void
     {
@@ -32,42 +37,46 @@ class GeoRoutesMiddlewareTest extends TestCase
         $this->next = function () {
             return 'User got through';
         };
-        $this->request = new Request();
+        $this->request = Mockery::mock(Request::class);
+        $this->route = Mockery::mock(Route::class);
         $this->location = Mockery::mock('overload:Location');
     }
 
     public function tearDown(): void
     {
+        parent::tearDown();
+
         Mockery::close();
     }
 
-    /**
-     * @test
-     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
-     */
+    /** @test */
     public function denyDeniesCountry()
     {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
         $this->location->shouldReceive('get')
             ->once()
             ->andReturn((object)['countryCode' => 'us']);
-        $this->middleware->handle($this->request, $this->next, 'deny', 'us');
+
+        $this->setGeoConstraint('deny', 'us');
+
+        $this->middleware->handle($this->request, $this->next);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function middlewareAllowsAccess()
     {
+        $this->setGeoConstraint('allow', 'us');
+
         $this->location->shouldReceive('get')
             ->once()
             ->andReturn((object)['countryCode' => 'us']);
-        $output = $this->middleware->handle($this->request, $this->next, 'allow', 'us');
+
+
+        $output = $this->middleware->handle($this->request, $this->next);
         $this->assertEquals('User got through', $output);
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function middlewareExecutesCallback()
     {
         $mockClass = Mockery::mock('alias:mockClass');
@@ -80,10 +89,37 @@ class GeoRoutesMiddlewareTest extends TestCase
             ->once()
             ->andReturn((object)['countryCode' => 'ca']);
 
-        $callback = serialize(['mockClass::callback', ['arg']]);
+        $callback = ['mockClass::callback', ['arg']];
 
-        $output = $this->middleware->handle($this->request, $this->next, 'allow', 'us', $callback);
+        $this->setGeoConstraint('allow', 'us', $callback);
+
+        $output = $this->middleware->handle($this->request, $this->next);
 
         $this->assertEquals('MockCallback', $output);
+    }
+
+    /**
+     * Set the route geo constraint.
+     *
+     * @param string $strategy
+     * @param array|string $countries
+     * @param array $callback
+     *
+     * @return void
+     */
+    protected function setGeoConstraint(string $strategy, $countries, array $callback = null)
+    {
+        $this->request->shouldReceive('route')
+                    ->once()
+                    ->andReturn($this->route);
+
+        $this->route->shouldReceive('getAction')
+                    ->with('geo')
+                    ->once()
+                    ->andReturn([
+                        'strategy' => $strategy,
+                        'countries' => (array)$countries,
+                        'callback' => $callback
+                    ]);
     }
 }

--- a/tests/Unit/GeoRoutesMiddlewareTest.php
+++ b/tests/Unit/GeoRoutesMiddlewareTest.php
@@ -98,6 +98,24 @@ class GeoRoutesMiddlewareTest extends TestCase
         $this->assertEquals('MockCallback', $output);
     }
 
+    /** @test */
+    public function middlewareThrowsExceptionIfTheGeoAttributeIsInvalid()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('The GeoRoute constraint is invalid.');
+
+        $this->request->shouldReceive('route')
+                    ->once()
+                    ->andReturn($this->route);
+
+        $this->route->shouldReceive('getAction')
+                    ->with('geo')
+                    ->once()
+                    ->andReturn([]);
+
+        $output = $this->middleware->handle($this->request, $this->next);
+    }
+
     /**
      * Set the route geo constraint.
      *

--- a/tests/Unit/GeoRoutesMiddlewareTest.php
+++ b/tests/Unit/GeoRoutesMiddlewareTest.php
@@ -3,12 +3,11 @@
 namespace LaraCrafts\GeoRoutes\Tests\Unit;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use LaraCrafts\GeoRoutes\Http\Middleware\GeoRoutesMiddleware;
 use LaraCrafts\GeoRoutes\Tests\TestCase;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Illuminate\Routing\Route;
-use Stevebauman\Location\Facades\Location;
 
 class GeoRoutesMiddlewareTest extends TestCase
 {
@@ -137,7 +136,7 @@ class GeoRoutesMiddlewareTest extends TestCase
                     ->andReturn([
                         'strategy' => $strategy,
                         'countries' => (array)$countries,
-                        'callback' => $callback
+                        'callback' => $callback,
                     ]);
     }
 }


### PR DESCRIPTION
This PR adds a `geo` attribute to the route `action` array which is more "Laravel-ish".
---

This will improve performance as we no longer do need to serialize the callback and follow a certain "schema" to define the middleware parameters string as in the following piece of code:

```php
'geo:' . $this->strategy . ',' . implode('&', $this->countries) .
            ($this->callback ? ',' . serialize($this->callback) : '');
```

**Note:** There is an increase of 20 seconds in the build time, this does not mean the code is slower as the tests now have 3 more assertions. 

<details>
<summary>Builds Screenshot</summary>
<img src="https://i.paste.pics/d4e6edea5ac8264e8db14d31d5d2a946.png">
</details>

Developers can now also define route attributes manually which is not the best way to do so, but for developers that prefer verbosity, they can now write something like the following:

```php
Route::get('/foo', ['geo' => ['strategy' => 'allow', 'countries' => ['us', 'ca'], 'callback' => 'Foo@bar']]);
```