### PR TITLE
Fix location testing ip being overwritten by geo-routes

### DIFF
--- a/src/DeterminesGeoAccess.php
+++ b/src/DeterminesGeoAccess.php
@@ -10,18 +10,17 @@ trait DeterminesGeoAccess
     /**
      * Determine if the request should be allowed through.
      *
-     * @param \Illuminate\Http\Request $request
      * @param array $countries
      * @param string $strategy
      * @return bool
      */
-    protected function shouldHaveAccess(Request $request, array $countries, string $strategy)
+    protected function shouldHaveAccess(array $countries, string $strategy)
     {
         if (!$countries) {
             return $strategy !== 'allow';
         }
 
-        $requestCountry = Location::get($request->ip())->countryCode;
+        $requestCountry = Location::get()->countryCode;
 
         if ($strategy === 'allow') {
             return in_array($requestCountry, $countries);

--- a/src/Http/Middleware/GeoMiddleware.php
+++ b/src/Http/Middleware/GeoMiddleware.php
@@ -22,7 +22,7 @@ class GeoMiddleware
         $countries = config()->get('geo-routes.global.countries');
         $strategy = config()->get('geo-routes.global.strategy');
 
-        if (!$this->shouldHaveAccess($request, $countries, $strategy)) {
+        if (!$this->shouldHaveAccess($countries, $strategy)) {
             abort(401);
         }
 

--- a/src/Http/Middleware/GeoRoutesMiddleware.php
+++ b/src/Http/Middleware/GeoRoutesMiddleware.php
@@ -24,7 +24,7 @@ class GeoRoutesMiddleware
     {
         $countries = explode('&', $countries);
 
-        if ($this->shouldHaveAccess($request, $countries, $strategy)) {
+        if ($this->shouldHaveAccess($countries, $strategy)) {
             return $next($request);
         }
 


### PR DESCRIPTION
This fixes #28 where right now using the testing tools supplied by `stevebauman/location` are overwritten by this package's middleware.