### PR TITLE
Change the type of the `strategy` parameter to boolean and rename it to `allowed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ Route::get('/home', 'FooController@bar')->from('ca', 'de', 'fr')->deny();
 
 Under the hood, the `allowFrom` and the `denyFrom` methods set the `geo` attribute on the route which is an array containing the following parameters:
 - [array] **`countries`**: The list of countries covered by the *geo-constraint*.
-- [string] **`strategy`**: Determines whether to allow or deny access, the value can only be **allow** or **deny**.
+- [boolean] **`allowed`**: Determines whether to allow or deny access from the configured countries.
 - [array] **`callback`** (optional): The callback that will be invoked once the access is denied and its arguments.
 
 Therefore, if you are more into verbosity, you can define your `GeoRoutes` in the following way:
 
 ```php
-Route::get([ 'geo' => ['countries' => ['us', 'ca'], 'strategy' => 'allow', 'callback' => [$myCallback, $myArgs]] ], function() {
+Route::get([ 'geo' => ['countries' => ['us', 'ca'], 'allowed' => true, 'callback' => [$myCallback, $myArgs]] ], function() {
     //
 });
 ```

--- a/config/global.php
+++ b/config/global.php
@@ -15,17 +15,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Strategy
+    | Allowed
     |--------------------------------------------------------------------------
     |
-    | The strategy determines what should be done with the country codes
-    | entered under 'countries'. The strategy will default to 'deny' if no
-    | valid value is set.
-    |
-    | Allowed values: allow, deny
+    | The allowed parameter determines whether to allow access from the configured
+    | countries.
     |
     */
-    'strategy' => 'deny',
+    'allowed' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/DeterminesGeoAccess.php
+++ b/src/DeterminesGeoAccess.php
@@ -10,18 +10,19 @@ trait DeterminesGeoAccess
      * Determine if the request should be allowed through.
      *
      * @param array $countries
-     * @param string $strategy
+     * @param boolean $allowed
+     *
      * @return bool
      */
-    protected function shouldHaveAccess(array $countries, string $strategy)
+    protected function shouldHaveAccess(array $countries, bool $allowed)
     {
         if (!$countries) {
-            return $strategy !== 'allow';
+            return !$allowed;
         }
 
         $requestCountry = Location::get()->countryCode;
 
-        if ($strategy === 'allow') {
+        if ($allowed) {
             return in_array($requestCountry, $countries);
         }
 

--- a/src/GeoRoute.php
+++ b/src/GeoRoute.php
@@ -48,26 +48,28 @@ class GeoRoute
     protected $route;
 
     /**
-     * The rule's strategy.
+     * Determines if the access is allowed to
+     * the given countries.
      *
-     * @var string
+     * @var boolean
      */
-    protected $strategy;
+    protected $allowed;
 
     /**
      * Create a new GeoRoute instance.
      *
      * @param \Illuminate\Routing\Route $route
      * @param array $countries
-     * @param string $strategy
+     * @param boolean $allowed
+     *
      * @throws \InvalidArgumentException
      */
-    public function __construct(Route $route, array $countries, string $strategy)
+    public function __construct(Route $route, array $countries, bool $allowed)
     {
         $this->applied = false;
         $this->countries = array_map('strtoupper', $countries);
         $this->route = $route;
-        $this->strategy = $strategy;
+        $this->allowed = $allowed;
 
         static::loadProxies();
     }
@@ -108,7 +110,7 @@ class GeoRoute
      */
     public function allow()
     {
-        $this->strategy = 'allow';
+        $this->allowed = true;
 
         return $this;
     }
@@ -125,7 +127,7 @@ class GeoRoute
         $action = $this->route->getAction();
         $action['middleware'][] = 'geo';
         $action['geo'] = [
-            'strategy' => $this->strategy,
+            'allowed' => $this->allowed,
             'countries' => (array)$this->countries,
             'callback' => $this->callback,
         ];
@@ -142,7 +144,7 @@ class GeoRoute
      */
     public function deny()
     {
-        $this->strategy = 'deny';
+        $this->allowed = false;
 
         return $this;
     }

--- a/src/GeoRoutesServiceProvider.php
+++ b/src/GeoRoutesServiceProvider.php
@@ -63,15 +63,15 @@ class GeoRoutesServiceProvider extends ServiceProvider
     protected function registerMacros()
     {
         Route::macro('allowFrom', function (string ...$countries) {
-            return new GeoRoute($this, $countries, 'allow');
+            return new GeoRoute($this, $countries, true);
         });
 
         Route::macro('denyFrom', function (string ...$countries) {
-            return new GeoRoute($this, $countries, 'deny');
+            return new GeoRoute($this, $countries, false);
         });
 
         Route::macro('from', function (string ...$countries) {
-            return new GeoRoute($this, $countries, 'allow');
+            return new GeoRoute($this, $countries, true);
         });
     }
 }

--- a/src/Http/Middleware/GeoMiddleware.php
+++ b/src/Http/Middleware/GeoMiddleware.php
@@ -20,9 +20,9 @@ class GeoMiddleware
     public function handle(Request $request, Closure $next)
     {
         $countries = config()->get('geo-routes.global.countries');
-        $strategy = config()->get('geo-routes.global.strategy');
+        $allowed = config()->get('geo-routes.global.allowed');
 
-        if (!$this->shouldHaveAccess($countries, $strategy)) {
+        if (!$this->shouldHaveAccess($countries, $allowed)) {
             abort(401);
         }
 

--- a/src/Http/Middleware/GeoRoutesMiddleware.php
+++ b/src/Http/Middleware/GeoRoutesMiddleware.php
@@ -17,7 +17,7 @@ class GeoRoutesMiddleware
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure $next
-     * @param string $strategy
+     * @param string $allowed
      * @param string $countries
      * @param string|null $callback
      *
@@ -37,14 +37,14 @@ class GeoRoutesMiddleware
         $validator = Validator::make($constraint, [
             'countries' => 'required|array|min:1',
             'countries.*' => 'string|min:2|max:2',
-            'strategy' => 'required|in:allow,deny',
+            'allowed' => 'required',
         ]);
 
         if ($validator->fails()) {
             throw new Exception("The GeoRoute constraint is invalid.");
         }
 
-        if ($this->shouldHaveAccess((array)$constraint['countries'], $constraint['strategy'])) {
+        if ($this->shouldHaveAccess((array)$constraint['countries'], $constraint['allowed'])) {
             return $next($request);
         }
 

--- a/tests/Unit/GeoRouteTest.php
+++ b/tests/Unit/GeoRouteTest.php
@@ -36,17 +36,17 @@ class GeoRouteTest extends TestCase
 
     public function testIfMiddlewareIsApplied()
     {
-        (new GeoRoute($this->route, ['nl'], 'allow'));
+        (new GeoRoute($this->route, ['nl'], true));
         $this->assertEquals('geo', last($this->route->middleware()));
 
-        (new GeoRoute($this->route, ['tn'], 'deny'));
+        (new GeoRoute($this->route, ['tn'], false));
         $this->assertEquals('geo', last($this->route->middleware()));
     }
 
 
     public function testDefaultCallback()
     {
-        (new GeoRoute($this->route, ['kr'], 'allow'));
+        (new GeoRoute($this->route, ['kr'], true));
 
         $this->location
             ->shouldReceive('get')
@@ -60,7 +60,7 @@ class GeoRouteTest extends TestCase
 
     public function testOrNotFoundCallback()
     {
-        (new GeoRoute($this->route, ['gb'], 'allow'))->orNotFound();
+        (new GeoRoute($this->route, ['gb'], true))->orNotFound();
 
         $this->location
             ->shouldReceive('get')
@@ -74,7 +74,7 @@ class GeoRouteTest extends TestCase
 
     public function testOrRedirectCallback()
     {
-        (new GeoRoute($this->route, ['uk'], 'allow'))->orRedirectTo('grault');
+        (new GeoRoute($this->route, ['uk'], true))->orRedirectTo('grault');
 
         $this->router->get('/quux', ['uses' => 'CorgeController@uier', 'as' => 'grault']);
 

--- a/tests/Unit/GeoRoutesMiddlewareTest.php
+++ b/tests/Unit/GeoRoutesMiddlewareTest.php
@@ -56,7 +56,7 @@ class GeoRoutesMiddlewareTest extends TestCase
             ->once()
             ->andReturn((object)['countryCode' => 'us']);
 
-        $this->setGeoConstraint('deny', 'us');
+        $this->setGeoConstraint(false, 'us');
 
         $this->middleware->handle($this->request, $this->next);
     }
@@ -64,7 +64,7 @@ class GeoRoutesMiddlewareTest extends TestCase
     /** @test */
     public function middlewareAllowsAccess()
     {
-        $this->setGeoConstraint('allow', 'us');
+        $this->setGeoConstraint(true, 'us');
 
         $this->location->shouldReceive('get')
             ->once()
@@ -90,7 +90,7 @@ class GeoRoutesMiddlewareTest extends TestCase
 
         $callback = ['mockClass::callback', ['arg']];
 
-        $this->setGeoConstraint('allow', 'us', $callback);
+        $this->setGeoConstraint(true, 'us', $callback);
 
         $output = $this->middleware->handle($this->request, $this->next);
 
@@ -118,13 +118,13 @@ class GeoRoutesMiddlewareTest extends TestCase
     /**
      * Set the route geo constraint.
      *
-     * @param string $strategy
+     * @param boolean $allowed
      * @param array|string $countries
      * @param array $callback
      *
      * @return void
      */
-    protected function setGeoConstraint(string $strategy, $countries, array $callback = null)
+    protected function setGeoConstraint(bool $allowed, $countries, array $callback = null)
     {
         $this->request->shouldReceive('route')
                     ->once()
@@ -134,7 +134,7 @@ class GeoRoutesMiddlewareTest extends TestCase
                     ->with('geo')
                     ->once()
                     ->andReturn([
-                        'strategy' => $strategy,
+                        'allowed' => $allowed,
                         'countries' => (array)$countries,
                         'callback' => $callback,
                     ]);


### PR DESCRIPTION
I thought it would be better having a boolean (in the [shouldHaveAccess](https://github.com/LaraCrafts/laravel-geo-routes/blob/f4a493666a8d4027ccf42515342d6116cac644d9/src/DeterminesGeoAccess.php#L16) method) evaluated instead of a string, it introduces a slight performance enhancement. Besides, in my humble opinion, it would be a bit more meaningful, code-wise, to use `true` or `false` instead of `'allow'` and `'deny'` to determine whether to authorize access or not.